### PR TITLE
Language driver template - https redirection to http to avoid resources get errors

### DIFF
--- a/language-guides/assets/index.html
+++ b/language-guides/assets/index.html
@@ -3,6 +3,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="http://neo4j-contrib.github.io/developer-resources/language-guides/assets/css/main.css">
     <title>Neo4j Movies</title>
+    <script type="text/javascript">
+        if (window.location.protocol == "https:") {
+        var restOfUrl = window.location.href.substr(6);
+        window.location.replace("http:" + restOfUrl);
+    }
+    </script>
 </head>
 
 <body>


### PR DESCRIPTION
Hi,

When running the example on a https host (e.g. with the heroku deploy button) , errors are triggered because resources included in template use http links.

![Imgur](http://i.imgur.com/nVsAEtO.png)

There are two solutions to avoid this problem : 
- Change all links in the templates folder and all drivers examples.
- Add a script to detect https and redirect to http

This P.R. proposes the second solution.

/cc @jexp 
