### PR TITLE
AWS update june 2018

### DIFF
--- a/guide-cloud-deployment/guide-cloud-deployment.adoc
+++ b/guide-cloud-deployment/guide-cloud-deployment.adoc
@@ -22,14 +22,27 @@ Topics include:
 Amazon Elastic Compute Cloud (Amazon EC2) is a web service that provides secure, resizable compute capacity in the cloud.
 It is designed to make web-scale cloud computing easier for developers.
 
-Starting from version 3.2.0, link:https://aws.amazon.com/marketplace/pp/B071P26C9D[Neo4j can be installed from the AWS marketplace^].
+There are several options for running on EC2, depending on what you want to do, detailed below.
 
-If you're using an earlier version, installing Neo4j on any Debian or Ubuntu system can be accomplished by following the instructions on link:http://debian.neo4j.org[our Debian Repository].
+=== Enterprise Causal Cluster in AWS Marketplace
 
-For other Linux distributions, download the link:http://neo4j.com/download/other-releases[Neo4j tarball]; it can be uncompressed and run interactively.
-Our operations manual discusses several ways to run link:{opsmanual}/installation/linux/[Neo4j as system service on Linux].
+link:https://aws.amazon.com/marketplace/pp/B07D441G55[Neo4j Enterprise Causal Clusters] can be launched directly.
 
-* link:/developer/guide-cloud-deployment/neo4j-cloud-aws-ec2-ami[Deploying Neo4j on EC2 using a custom Neo4j AMI]
+This option launches a multi-VM clustered configuration, with the choice to configure a number of aspects of the
+cluster, including number of core nodes, read replicas, hardware sizing, encrypted EBS volumes, and other options.
+
+=== Launching Directly from an AMI
+
+Instructions for launching VMs directly using Amazon's command line tool are provided 
+in the article on link:/developer/guide-cloud-deployment/neo4j-cloud-aws-ec2-ami[Deploying Neo4j on EC2 using a custom Neo4j AMI].
+Using this method, both Community and Enterprise options are available.
+
+=== Community Edition in AWS Marketplace
+
+link:https://aws.amazon.com/marketplace/pp/B071P26C9D[Neo4j Community can be installed from the AWS marketplace^].
+
+We recommend that for security group settings, you select the option to "Create new security group based on seller settings".
+This will ensure that when the instance is launched, the default ports that need to be open will be.
 
 == [.label]#Guide →# Google Cloud Platform (GCP)
 

--- a/guide-cloud-deployment/neo4j-cloud-aws-ec2-ami/neo4j-cloud-aws-ec2-ami.adoc
+++ b/guide-cloud-deployment/neo4j-cloud-aws-ec2-ami/neo4j-cloud-aws-ec2-ami.adoc
@@ -129,7 +129,7 @@ You can get system status for neo4j within the VM by executing:
 systemctl status neo4j
 ----
 
-An important thing to note about the AWS version of neo4j is that you should not modfiy the 
+An important thing to note about the AWS version of neo4j is that you should not modify the 
 /etc/neo4j/neo4j.conf file directly, but rather modify /etc/neo4j/neo4j.template.  Because the
 instance is dynamic and its IP may change over restarts, on AWS the normal configuration file is
 overwritten from that template each time the system service restarts.  The template file can be 
@@ -144,7 +144,7 @@ If we're in a different region than us-east-1, we can run the following command 
 ----
 aws ec2 describe-images \
   --filters "Name=name,Values=neo4j-enterprise-1-3.4.1*" \
-  --region us-west-2 --query "Images[*].ImageId"
+  --region us-east-1 --query "Images[*].ImageId"
 ----
 
 We can then substitute that `image-id` when link:#start-up-instance[starting up an instance].

--- a/guide-cloud-deployment/neo4j-cloud-aws-ec2-ami/neo4j-cloud-aws-ec2-ami.adoc
+++ b/guide-cloud-deployment/neo4j-cloud-aws-ec2-ami/neo4j-cloud-aws-ec2-ami.adoc
@@ -72,12 +72,13 @@ We'll use the `image-id` for us-east-1 but there are link:#other-regions[corresp
 [source,text]
 ----
 aws ec2 run-instances \
-  --image-id ami-f03c4fe6 \
+  --image-id ami-2a652655 \
   --count 1 \
   --instance-type m3.medium \
   --key-name $KEY_NAME \
   --security-groups $GROUP \
-  --query "Instances[*].InstanceId"
+  --query "Instances[*].InstanceId" \
+  --region us-east-1
 ----
 
 We don't yet have a Public DNS Name but it should be available in a few seconds.
@@ -88,12 +89,20 @@ We can run the following command to find out what it is:
 ----
 aws ec2 describe-instances \
   --instance-ids [InstanceId] \
-  --query "Reservations[*].Instances[*].PublicDnsName"
+  --query "Reservations[*].Instances[*].PublicDnsName" \
+  --region us-east-1
 ----
 
-Now let's navigate to `http://[PublicDnsName]:7474` and login with the user name `neo4j` and password `[InstanceId]`.
+Please note that your security group settings may affect whether or not a public DNS name is
+associated with your instance.  If this command does not work for you, check to make sure your
+security group is properly configured, and is not associated with a VPC.
 
-We'll be asked to update the password the first time we login.
+Now let's navigate to `https://[PublicDnsName]:7473` and login with the user name `neo4j` and password `neo4j`.
+
+Note that in some methods of launching neo4j on AWS, such as via the AWS marketplace, the password of
+an instance will be automatically set to the instance ID you launched.  In other cases, such as when
+launching enteprise AMIs directly, the password is left as the default "neo4j".  In either case, we
+recommend changing the password immediately after you launch.
 
 === How do I SSH into the instance?
 
@@ -111,6 +120,21 @@ You might get an error about the permissions on the pem file so don't forget to 
 chmod 600 $KEY_NAME.pem
 ----
 
+=== Interacting with the Neo4j Service
+
+You can get system status for neo4j within the VM by executing:
+
+[source,text]
+----
+systemctl status neo4j
+----
+
+An important thing to note about the AWS version of neo4j is that you should not modfiy the 
+/etc/neo4j/neo4j.conf file directly, but rather modify /etc/neo4j/neo4j.template.  Because the
+instance is dynamic and its IP may change over restarts, on AWS the normal configuration file is
+overwritten from that template each time the system service restarts.  The template file can be 
+edited as any normal neo4j.conf file.
+
 [[other-regions]]
 === How do I find the `image-id` for other regions?
 
@@ -119,17 +143,20 @@ If we're in a different region than us-east-1, we can run the following command 
 [source,text]
 ----
 aws ec2 describe-images \
-  --filters "Name=product-code,Values=3yl6wt8a1ty4izxxfer68wkie" "Name=product-code.type,Values=marketplace" \
-  --query "Images[*].ImageId" \
-  --region [Region]
+  --filters "Name=name,Values=neo4j-enterprise-1-3.4.1*" \
+  --region us-west-2 --query "Images[*].ImageId"
 ----
 
 We can then substitute that `image-id` when link:#start-up-instance[starting up an instance].
+
+This same filter command can be used to locate AMIs for neo4j-community.
 
 === Terminating the instance
 
 Once we've finished using the instance we can run the following command to terminate it:
 
 ```
-aws ec2 terminate-instances --instance-ids [InstanceId]
+aws ec2 terminate-instances \
+  --instance-ids [InstanceId] \
+  --region us-east-1
 ```


### PR DESCRIPTION
Since these pages were last updated, we added causal cluster in AWS marketplace, and updated a lot of the available AMIs.   Some of the older commands needed slight updates to "just work" under any CLI configuration setting (for example specifying a region by default).

Recently took user feedback via slack about this page, and these improvements are intended to get around observed confusions, and document the expanding options for cloud hosting.