### PR TITLE
Remove SDN as comparable to Neo4j-OGM.

### DIFF
--- a/language-guides/neo4j-ogm/neo4j-ogm.adoc
+++ b/language-guides/neo4j-ogm/neo4j-ogm.adoc
@@ -35,7 +35,7 @@ While using the Cypher query language alongside the Java driver works well for s
 That's where object graph mappers come in; they take your existing domain objects (POJOs) and map them to Neo4j.
 The great benefit with this approach is that with graph databases, there is no data-model impedence mismatch like there is with relational databases.
 
-Besides the Neo4j-OGM, there are also link:../spring-data-neo4j[Spring Data Neo4j], link:../java#hibernate[Hibernate-OGM] and others.
+Besides the Neo4j-OGM, there is also link:../java#hibernate[Hibernate-OGM] and others.
 
 We created the Neo4j-OGM as a standalone, simple object graph mapper for Java which also acts as the base for Spring Data Neo4j.
 

--- a/language-guides/neo4j-ogm/neo4j-ogm.adoc
+++ b/language-guides/neo4j-ogm/neo4j-ogm.adoc
@@ -36,6 +36,7 @@ That's where object graph mappers come in; they take your existing domain object
 The great benefit with this approach is that with graph databases, there is no data-model impedence mismatch like there is with relational databases.
 
 Besides the Neo4j-OGM, there is also link:../java#hibernate[Hibernate-OGM] and others.
+If you want more abstraction link:../spring-data-neo4j[Spring Data Neo4j] can give you a Domain Driver Design (DDD) approach.
 
 We created the Neo4j-OGM as a standalone, simple object graph mapper for Java which also acts as the base for Spring Data Neo4j.
 


### PR DESCRIPTION
Neo4j-OGM is on the same level of abstraction as Hibernate-OGM.
Spring Data Neo4j is not on this level and gets removed.