### PR TITLE
Updated links for in-production online training to new admin course

### DIFF
--- a/_templates/menu_partial.erb
+++ b/_templates/menu_partial.erb
@@ -146,7 +146,7 @@
                     <li><a href="/developer/guide-cloud-deployment/">Cloud Deployment</a></li>
                     <li><a href="/developer/in-production/guide-performance-tuning/">Performance Tuning</a></li>
                     <li><a href="/developer/in-production/guide-clustering-neo4j/">Clustering Neo4j</a></li>
-	                <li><a href="/graphacademy/online-course-prod/">In Production Course</a></li>
+	                <li><a href="/graphacademy/online-training/neo4j-administration/">Online Course: Neo4j Administration</a></li>
                 </ul>
             </div>
         </dd>
@@ -177,7 +177,7 @@
                 <ul>
 	                <li><a href="/graphacademy/online-course-getting-started/">Getting Started Course</a></li>
 	                <li><a href="/developer/resources/ruby-course/">Ruby / Rails Course</a></li>
-	                <li><a href="/graphacademy/online-course-prod/">In Production Course</a></li>
+	                <li><a href="/graphacademy/online-training/neo4j-administration/">Online Course: Neo4j Administration</a></li>
                     <li><a href="/docs/">Neo4j Documentation</a></li>
                     <ul>
 	                    <li><a href="/docs/developer-manual/current/">Developer Manual</a></li>

--- a/resources/resources.adoc
+++ b/resources/resources.adoc
@@ -76,7 +76,7 @@ The online course are a great way to get started in a self-paced fashion:
 
 * link:/online-training[Neo4j Online Training^]
 ** link:/graphacademy/online-course-getting-started/[Getting Started with Neo4j Course^]
-** link:/graphacademy/online-course-prod/[Neo4j in Production Course^]
+** link:/graphacademy/online-training/neo4j-administration/[Neo4j Administration^]
 ** link:/developer/ruby-course/[Getting Started with Neo4j and Ruby Course^]
 
 


### PR DESCRIPTION
Updated references to the old in-production course to now link to the new Neo4j Administration online training course.